### PR TITLE
RR-2: Test cases

### DIFF
--- a/test/screens/initial_signup_screen_test.dart
+++ b/test/screens/initial_signup_screen_test.dart
@@ -10,32 +10,91 @@ void main() {
     'Initial Sign Up Screen: ',
     () {
       testWidgets(
-          'When CDO Button is clicked, user is redirected to the CDO agreement screen',
-          (WidgetTester tester) async {
-        final mockObserver = MockNavigatorObserver();
-        await tester.pumpWidget(
-          MaterialApp(
-            home: const InitialSignUpScreen(),
-            navigatorObservers: [mockObserver],
-          ),
-        );
+        'When CDO Button is clicked, user is redirected to the CDO agreement screen',
+        (WidgetTester tester) async {
+          final mockObserver = MockNavigatorObserver();
+          await tester.pumpWidget(
+            MaterialApp(
+              home: const InitialSignUpScreen(),
+              navigatorObservers: [mockObserver],
+            ),
+          );
 
-        await tester.tap(
-          find.text('CDO'),
-        );
-        await tester.pumpAndSettle();
+          await tester.tap(
+            find.text('CDO'),
+          );
+          await tester.pumpAndSettle();
 
-        expect(
-          find.byType(AgreemantScreen),
-          findsOneWidget,
-        );
+          expect(
+            find.byType(AgreemantScreen),
+            findsOneWidget,
+          );
 
-        expect(
-            (tester.firstWidget(find.byType(FloatingActionButton))
-                    as FloatingActionButton)
-                .backgroundColor,
-            const Color(0xFF009FE3));
-      });
+          expect(
+              (tester.firstWidget(find.byType(FloatingActionButton))
+                      as FloatingActionButton)
+                  .backgroundColor,
+              const Color(0xFF009FE3));
+        },
+      );
+
+      testWidgets(
+        'When Solicitor Button is clicked, user is redirected to the Solicitor agreement screen',
+        (WidgetTester tester) async {
+          final mockObserver = MockNavigatorObserver();
+          await tester.pumpWidget(
+            MaterialApp(
+              home: const InitialSignUpScreen(),
+              navigatorObservers: [mockObserver],
+            ),
+          );
+
+          await tester.tap(
+            find.text('Solicitor'),
+          );
+          await tester.pumpAndSettle();
+
+          expect(
+            find.byType(AgreemantScreen),
+            findsOneWidget,
+          );
+
+          expect(
+              (tester.firstWidget(find.byType(FloatingActionButton))
+                      as FloatingActionButton)
+                  .backgroundColor,
+              const Color(0xFF009B14));
+        },
+      );
+
+      testWidgets(
+        'When Firm Rep Button is clicked, user is redirected to the Firm Rep agreement screen',
+        (WidgetTester tester) async {
+          final mockObserver = MockNavigatorObserver();
+          await tester.pumpWidget(
+            MaterialApp(
+              home: const InitialSignUpScreen(),
+              navigatorObservers: [mockObserver],
+            ),
+          );
+
+          await tester.tap(
+            find.text('Firm Representative'),
+          );
+          await tester.pumpAndSettle();
+
+          expect(
+            find.byType(AgreemantScreen),
+            findsOneWidget,
+          );
+
+          expect(
+              (tester.firstWidget(find.byType(FloatingActionButton))
+                      as FloatingActionButton)
+                  .backgroundColor,
+              const Color(0xFF951B81));
+        },
+      );
     },
   );
 }

--- a/test/screens/initial_signup_screen_test.dart
+++ b/test/screens/initial_signup_screen_test.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group(
+    'Initial Sign Up Screen: ',
+    () {
+      testWidgets(
+        'When Sign Up Button is clicked, user is redirected to Sign Up Page',
+        (WidgetTester tester) async {},
+      );
+    },
+  );
+}

--- a/test/screens/initial_signup_screen_test.dart
+++ b/test/screens/initial_signup_screen_test.dart
@@ -1,13 +1,41 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:rapid_reps/screens/export.dart';
+
+class MockNavigatorObserver extends Mock implements NavigatorObserver {}
 
 void main() {
   group(
     'Initial Sign Up Screen: ',
     () {
       testWidgets(
-        'When Sign Up Button is clicked, user is redirected to Sign Up Page',
-        (WidgetTester tester) async {},
-      );
+          'When CDO Button is clicked, user is redirected to the CDO agreement screen',
+          (WidgetTester tester) async {
+        final mockObserver = MockNavigatorObserver();
+        await tester.pumpWidget(
+          MaterialApp(
+            home: const InitialSignUpScreen(),
+            navigatorObservers: [mockObserver],
+          ),
+        );
+
+        await tester.tap(
+          find.text('CDO'),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          find.byType(AgreemantScreen),
+          findsOneWidget,
+        );
+
+        expect(
+            (tester.firstWidget(find.byType(FloatingActionButton))
+                    as FloatingActionButton)
+                .backgroundColor,
+            const Color(0xFF009FE3));
+      });
     },
   );
 }

--- a/test/screens/login_screen_test.dart
+++ b/test/screens/login_screen_test.dart
@@ -25,26 +25,27 @@ void main() {
       );
 
       testWidgets(
-          'When Sign Up Button is clicked, user is redirected to Sign Up Page',
-          (WidgetTester tester) async {
-        final mockObserver = MockNavigatorObserver();
-        await tester.pumpWidget(
-          MaterialApp(
-            home: const LoginScreen(),
-            navigatorObservers: [mockObserver],
-          ),
-        );
+        'When Sign Up Button is clicked, user is redirected to Sign Up Page',
+        (WidgetTester tester) async {
+          final mockObserver = MockNavigatorObserver();
+          await tester.pumpWidget(
+            MaterialApp(
+              home: const LoginScreen(),
+              navigatorObservers: [mockObserver],
+            ),
+          );
 
-        await tester.tap(
-          find.text('Sign Up'),
-        );
-        await tester.pumpAndSettle();
+          await tester.tap(
+            find.text('Sign Up'),
+          );
+          await tester.pumpAndSettle();
 
-        expect(
-          find.byType(InitialSignUpScreen),
-          findsOneWidget,
-        );
-      });
+          expect(
+            find.byType(InitialSignUpScreen),
+            findsOneWidget,
+          );
+        },
+      );
     },
   );
 }


### PR DESCRIPTION
I made some test cases for when a user clicks on each of the buttons on the initial sign up screen except for the back button. 

To do tests for the back button we would have to use named routes instead of the dynamic routes that we have now (so we would have to make something like a routing table in main.dart and then change all of the navigator logic to use the routing table instead of specifying the screen to build. I also havent made any test cases for the individual sign up screens as I thought it would be better to do it after the connection to firebase was made. 

After we have connected the app to firebase, I can then start making some integration tests which would act like a user using the app from the beginning of the application as the current tests I have written work by loading a specific screen in the app and then checking what is on that screen. That is another reason why I thought it would be better to make the test cases for the individual sign up screens after the firebase connections as if I do using the unit tests Ive made, I would have to repeat code to launch the app and navigate to the specific page for each button on that page as the colours on the individual agreement and sign up pages are passed as parameters/arguments between the pages.

The way the test cases for the intial sign up screen work is by checking what the colour of the floating action button is when the user clicks on a specific user button as I assumed it would be easier to implement. This also means that a user must accept and agree to the terms before they enter in their information into the sign up form. If John wants we could move the order of these screens so after clicking the CDO button it takes a user to the sign up form but then we would have to pass the information from the sign up form to the agreemant page.

If you want to you can look over the test cases I have written as see if you can improve them/make them more streamlined or if you want, you can write some test cases for some of the features I have missed.